### PR TITLE
Make link click area larger.

### DIFF
--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -104,7 +104,11 @@ export default class Sandbox extends React.Component {
     onNodePositionChange = (nodeId, x, y) =>
         console.info(`Node ${nodeId} is moved to new position. New position is (${x}, ${y}) (x,y)`);
 
-    onKeyDownLink = (source, target) => console.info(`On keydown link between ${source} and ${target}`);
+    onKeyDownLink = (event, source, target) => {
+        if (event.keyCode === KeyCodes.enter) {
+            console.info(`On keydown link between ${source} and ${target}`);
+        }
+    };
 
     /**
      * Sets on/off fullscreen visualization mode.

--- a/src/components/link/Link.jsx
+++ b/src/components/link/Link.jsx
@@ -63,8 +63,8 @@ export default class Link extends React.Component {
     handleOnMouseOutLink = () =>
         this.props.onMouseOutLink && this.props.onMouseOutLink(this.props.source, this.props.target);
 
-    handleOnKeyDownLink = () =>
-        this.props.onKeyDownLink && this.props.onKeyDownLink(this.props.source, this.props.target);
+    handleOnKeyDownLink = event =>
+        this.props.onKeyDownLink && this.props.onKeyDownLink(event, this.props.source, this.props.target);
 
     render() {
         const lineStyle = {
@@ -107,9 +107,26 @@ export default class Link extends React.Component {
             },
         };
 
+        const STROKE_WIDTH_LIMIT = 12;
+
+        const needClickHelperPath = this.props.onClickLink && this.props.strokeWidth < STROKE_WIDTH_LIMIT;
+
+        const clickHelperLineStyle = {
+            strokeWidth: STROKE_WIDTH_LIMIT,
+            stroke: this.props.stroke,
+            opacity: 0,
+            cursor: this.props.mouseCursor,
+        };
+        const clickHelperLineProps = {
+            className: this.props.className,
+            d: this.props.d,
+            onClick: this.handleOnClickLink,
+            style: clickHelperLineStyle,
+        };
         return (
             <g>
                 <path {...lineProps} id={id} />
+                {needClickHelperPath && <path {...clickHelperLineProps} id={`clickHelper-${id}`} />}
                 {label && (
                     <text style={{ textAnchor: "middle" }} {...textProps}>
                         <textPath href={`#${id}`} startOffset="50%">


### PR DESCRIPTION
**What does this PR do:**
1. Previously, it is hard for us to click the link as the link is too narrow. So we add another invisible path, which has 12 px as the width, and the path also has the click handler. 
  Note that our designer wants this selection area to be 44px in width, but this will cause an issue that, adjacent nodes may be overlapped by the invisible link, which make the node not clickable. And there is a limitation in SVG elements that, z-index does not work for SVG elements. So use 12px width as a workaround.

2. Add event in keydown handler for link.
